### PR TITLE
crop method returns string buffer instead of ctypes char array

### DIFF
--- a/turbojpeg.py
+++ b/turbojpeg.py
@@ -349,7 +349,7 @@ class TurboJPEG(object):
             self.__free(dest_array)
             if status != 0:
                 self.__report_error(handle)
-            return dest_buf
+            return dest_buf.raw
         finally:
             self.__destroy(handle)
 


### PR DESCRIPTION
crop method was returning a ctypes char array, now it returns a python string

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/pyturbojpeg/3)
<!-- Reviewable:end -->
